### PR TITLE
Custom AssertableHtmlElement classes

### DIFF
--- a/src/Concerns/AssertsHtmlElement.php
+++ b/src/Concerns/AssertsHtmlElement.php
@@ -843,6 +843,12 @@ trait AssertsHtmlElement
         return $this;
     }
 
+    /** Prefix the given attribute name with "data-" if applicable. */
+    protected function prefixDataAttribute(string $attribute): string
+    {
+        return (! str_starts_with($attribute, 'data-') ? 'data-' : '') . $attribute;
+    }
+
     /*
     |--------------------------------------------------------------------------
     | Assert Aria Attribute
@@ -909,21 +915,28 @@ trait AssertsHtmlElement
         return $this;
     }
 
-    /*
-    |--------------------------------------------------------------------------
-    | Internal
-    |--------------------------------------------------------------------------
-    */
-
-    /** Prefix the given attribute name with "data-" if applicable. */
-    protected function prefixDataAttribute(string $attribute): string
-    {
-        return (! str_starts_with($attribute, 'data-') ? 'data-' : '') . $attribute;
-    }
-
     /** Prefix the given attribute name with "aria-" if applicable. */
     protected function prefixAriaAttribute(string $attribute): string
     {
         return (! str_starts_with($attribute, 'aria-') ? 'aria-' : '') . $attribute;
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Assert If Null
+    |--------------------------------------------------------------------------
+    */
+
+    /**
+     * Assert only if the given input is null.
+     * Useful if you want to fail when a child element isn't matched before attempting to chain on more assertions.
+     */
+    protected function assertIfNull(mixed $value, ?string $message = null): static
+    {
+        if ($value === null) {
+            PHPUnit::fail($message ?? 'The given input was null.');
+        }
+
+        return $value;
     }
 }

--- a/src/Contracts/AssertableHtmlElementMatcherInterface.php
+++ b/src/Contracts/AssertableHtmlElementMatcherInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ziadoz\AssertableHtml\Contracts;
+
+use Dom\Element;
+use Dom\HTMLElement;
+
+interface AssertableHtmlElementMatcherInterface
+{
+    /** Return if the assertable is usable for the given element. */
+    public static function match(HTMLElement|Element $element): bool;
+}

--- a/src/Dom/AssertableHtmlElement.php
+++ b/src/Dom/AssertableHtmlElement.php
@@ -11,6 +11,7 @@ use Ziadoz\AssertableHtml\Concerns\AssertsHtmlElement;
 use Ziadoz\AssertableHtml\Concerns\IdentifiesElement;
 use Ziadoz\AssertableHtml\Concerns\Whenable;
 use Ziadoz\AssertableHtml\Concerns\Withable;
+use Ziadoz\AssertableHtml\Dom\Elements\AssertableHtmlFormElement;
 
 readonly class AssertableHtmlElement
 {
@@ -89,6 +90,29 @@ readonly class AssertableHtmlElement
         return $element !== null
             ? new ReflectionClass(static::class)->newLazyProxy(fn () => new static($element))
             : null;
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Elements
+    |--------------------------------------------------------------------------
+    */
+
+    // @todo: element()/elements()
+    // @todo: component()/components()
+
+    public function element(?callable $callable = null): static
+    {
+        $element = match (true) {
+            $this->element->matches('form') => new AssertableHtmlFormElement($this->element),
+            default                         => $this,
+        };
+
+        if ($callable) {
+            $callable($element);
+        }
+
+        return $element;
     }
 
     /*

--- a/src/Dom/Elements/AssertableHtmlFormElement.php
+++ b/src/Dom/Elements/AssertableHtmlFormElement.php
@@ -4,10 +4,19 @@ declare(strict_types=1);
 
 namespace Ziadoz\AssertableHtml\Dom\Elements;
 
+use Dom\Element;
+use Dom\HTMLElement;
+use Ziadoz\AssertableHtml\Contracts\AssertableHtmlElementMatcherInterface;
 use Ziadoz\AssertableHtml\Dom\AssertableHtmlElement;
 
-readonly class AssertableHtmlFormElement extends AssertableHtmlElement
+readonly class AssertableHtmlFormElement extends AssertableHtmlElement implements AssertableHtmlElementMatcherInterface
 {
+    /** Return if the assertable is usable for the given element. */
+    public static function match(HTMLElement|Element $element): bool
+    {
+        return $element->matches('form');
+    }
+
     /** Assert the form's method is GET. */
     public function assertMethodGet(?string $message = null): static
     {

--- a/src/Dom/Elements/AssertableHtmlFormElement.php
+++ b/src/Dom/Elements/AssertableHtmlFormElement.php
@@ -1,27 +1,50 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Ziadoz\AssertableHtml\Dom\Elements;
 
 use Ziadoz\AssertableHtml\Dom\AssertableHtmlElement;
 
 readonly class AssertableHtmlFormElement extends AssertableHtmlElement
 {
+    /** Assert the form's method is GET. */
     public function assertMethodGet(?string $message = null): static
     {
         return $this->assertMethod('get', $message);
     }
 
+    /** Assert the form's method is POST. */
     public function assertMethodPost(?string $message = null): static
     {
         return $this->assertMethod('post', $message);
     }
 
+    /** Assert the form's method is PUT (via hidden _method input). */
+    public function assertMethodPut(?string $message = null): static
+    {
+        return $this->assertHiddenInputMethod('put', $message);
+    }
+
+    /** Assert the form's method is PATCH (via hidden _method input). */
+    public function assertMethodPatch(?string $message = null): static
+    {
+        return $this->assertHiddenInputMethod('patch', $message);
+    }
+
+    /** Assert the form's method is DELETE (via hidden _method input). */
+    public function assertMethodDelete(?string $message = null): static
+    {
+        return $this->assertHiddenInputMethod('delete', $message);
+    }
+
+    /** Assert the form's method matches the given value. */
     private function assertMethod(string $method, ?string $message = null): static
     {
         $this->attributes->assertAttribute('method', function (?string $value) use ($method): bool {
             return trim(strtolower($this->attributes['method'] ?? '')) === $method;
         }, $message ?? sprintf(
-            "The form element [%s] method isn't %s.",
+            "The element [%s] method isn't %s.",
             $this->identifier(),
             strtoupper($method),
         ));
@@ -29,18 +52,44 @@ readonly class AssertableHtmlFormElement extends AssertableHtmlElement
         return $this;
     }
 
+    /** Assert the form's hidden _method input matches the given value. */
+    private function assertHiddenInputMethod(string $method, ?string $message = null): static
+    {
+        $this->assertIfNull($this->querySelector('input[type="hidden"][name="_method"]'), sprintf(
+            "The element [%s] doesn't contain a hidden _method input.",
+            $this->identifier(),
+        ))->assertAttribute('value', function (?string $value) use ($method): bool {
+            return trim(strtolower($value)) === $method;
+        }, $message ?? sprintf(
+            "The element [%s] doesn't contain a %s hidden _method input.",
+            $this->identifier(),
+            strtoupper($method),
+        ));
+
+        return $this;
+    }
+
+    /** Assert the form's enctype attribute is multipart/form-data. */
     public function assertAcceptsUploads(?string $message = null): static
     {
         $this->attributes->assertAttribute('enctype', function (?string $value): bool {
             return trim(strtolower($value)) === 'multipart/form-data';
         }, $message ?? sprintf(
-            "The form element [%s] enctype isn't multipart/form-data.",
+            "The element [%s] enctype isn't multipart/form-data.",
             $this->identifier(),
         ));
 
         return $this;
     }
 
-    // @todo: Laravel
-    // _method => PUT, PATCH, DELETE
+    /** Assert the form's action matches the given value. */
+    public function assertAction(string $value, bool $normaliseWhitespace = false, ?string $message = null): static
+    {
+        $this->attributes->assertEquals('action', $value, $normaliseWhitespace, $message ?? sprintf(
+            "The element [%s] action doesn't match the given value.",
+            $this->identifier(),
+        ));
+
+        return $this;
+    }
 }

--- a/src/Dom/Elements/AssertableHtmlFormElement.php
+++ b/src/Dom/Elements/AssertableHtmlFormElement.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Ziadoz\AssertableHtml\Dom\Elements;
+
+use Ziadoz\AssertableHtml\Dom\AssertableHtmlElement;
+
+readonly class AssertableHtmlFormElement extends AssertableHtmlElement
+{
+    public function assertMethodGet(?string $message = null): static
+    {
+        return $this->assertMethod('get', $message);
+    }
+
+    public function assertMethodPost(?string $message = null): static
+    {
+        return $this->assertMethod('post', $message);
+    }
+
+    private function assertMethod(string $method, ?string $message = null): static
+    {
+        $this->attributes->assertAttribute('method', function (?string $value) use ($method): bool {
+            return trim(strtolower($this->attributes['method'] ?? '')) === $method;
+        }, $message ?? sprintf(
+            "The form element [%s] method isn't %s.",
+            $this->identifier(),
+            strtoupper($method),
+        ));
+
+        return $this;
+    }
+
+    public function assertAcceptsUploads(?string $message = null): static
+    {
+        $this->attributes->assertAttribute('enctype', function (?string $value): bool {
+            return trim(strtolower($value)) === 'multipart/form-data';
+        }, $message ?? sprintf(
+            "The form element [%s] enctype isn't multipart/form-data.",
+            $this->identifier(),
+        ));
+
+        return $this;
+    }
+
+    // @todo: Laravel
+    // _method => PUT, PATCH, DELETE
+}

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -10,6 +10,7 @@ use Ziadoz\AssertableHtml\Dom\AssertableHtmlDocument;
 use Ziadoz\AssertableHtml\Dom\AssertableHtmlElement;
 use Ziadoz\AssertableHtml\Dom\AssertableHtmlElementsList;
 use Ziadoz\AssertableHtml\Dom\AssertableText;
+use Ziadoz\AssertableHtml\Dom\Elements\AssertableHtmlFormElement;
 use Ziadoz\AssertableHtml\Tests\TestCase;
 
 class IntegrationTest extends TestCase
@@ -42,7 +43,7 @@ class IntegrationTest extends TestCase
                 </ul>
 
                 <!-- Form -->
-                <form method="get" action="/foo/bar" enctype="multipart/form-data">
+                <form method="post" action="/foo/bar" enctype="multipart/form-data">
                     <label>Name <input type="text" name="name" value="Foo Bar"></label>
                     <label>Age <input type="number" name="age" value="42"></label>
                     <button type="submit">Save</button>
@@ -307,5 +308,16 @@ class IntegrationTest extends TestCase
             ->assertText(function (AssertableText $text): bool {
                 return $text->startsWith('I') && $text->endsWith('.') && $text->contains('test');
             });
+
+        /*
+        |--------------------------------------------------------------------------
+        | Assertable Custom Elements
+        |--------------------------------------------------------------------------
+        */
+
+        $html->querySelector('form')->element(function (AssertableHtmlFormElement $form): void {
+            $form->assertMethodPost();
+            $form->assertAcceptsUploads();
+        });
     }
 }

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -42,6 +42,9 @@ class IntegrationTest extends TestCase
                     <li id="baz">Baz</li>
                 </ul>
 
+                <!-- Custom Element -->
+                <my-web-component>I am a web component.</my-web-component>
+
                 <!-- Form -->
                 <form method="post" action="/foo/bar" enctype="multipart/form-data">
                     <label>Name <input type="text" name="name" value="Foo Bar"></label>
@@ -49,11 +52,13 @@ class IntegrationTest extends TestCase
                     <button type="submit">Save</button>
                 </form>
 
-                <-- Custom Element -->
-                <my-web-component>I am a web component.</my-web-component>
+                <!-- Form (Hidden Input Method) -->
+                <form>
+                    <input type="hidden" name="_method" value="PUT">
+                </form>
             </body>
             </html>
-        HTML, LIBXML_NOERROR);
+        HTML);
 
         /*
         |--------------------------------------------------------------------------
@@ -336,9 +341,15 @@ class IntegrationTest extends TestCase
         |--------------------------------------------------------------------------
         */
 
+        // Forms
         $html->querySelector('form')->element(function (AssertableHtmlFormElement $form): void {
             $form->assertMethodPost();
             $form->assertAcceptsUploads();
+            $form->assertAction('/foo/bar');
+        });
+
+        $html->querySelector('form:has(input[type="hidden"][name="_method"]')->element(function (AssertableHtmlFormElement $form): void {
+            $form->assertMethodPut();
         });
     }
 }


### PR DESCRIPTION
This PR adds the ability to return custom element assertable classes:

```
$form->element(function (AssertableHtmlFormElement $form) {
    $form->assertMethodPost();
    $form->assertAction('/foo/bar');
    $form->assertAcceptsUploads();
    $form->assertContainsFileUploadInputs();
});
```

Investigate original upgradable element idea: `$assertableElement->upgrade()` which returns `AssertableFormElement`.