### PR TITLE
Switch class_uses to version_compare

### DIFF
--- a/src/AssertableHtmlServiceProvider.php
+++ b/src/AssertableHtmlServiceProvider.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Ziadoz\AssertableHtml;
 
+use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Support\Traits\Macroable;
 use Illuminate\Testing\TestComponent;
 use Illuminate\Testing\TestResponse;
 use Illuminate\Testing\TestView;
@@ -23,7 +23,7 @@ class AssertableHtmlServiceProvider extends ServiceProvider
 
             // This functionality is only available in the point release after I added it to Laravel.
             // @see: https://github.com/laravel/framework/pull/54359
-            if (in_array(Macroable::class, class_uses(TestComponent::class) ?? [])) {
+            if (version_compare(Application::VERSION, '11.41.0', '>=')) {
                 TestComponent::mixin(new TestComponentMixins);
             }
         }


### PR DESCRIPTION
This switches the trait check for a version comparison as it was included in [11.41.0](https://github.com/laravel/framework/releases/tag/v11.41.0) 

Which shouldddddd also be more efficient  

I kept the comments as still relevant 

Feel free to close, but I wanted a reason to use version_compare