### PR TITLE
Update TestComponentMixins.php

### DIFF
--- a/src/Mixins/TestComponentMixins.php
+++ b/src/Mixins/TestComponentMixins.php
@@ -13,7 +13,7 @@ class TestComponentMixins
     public function assertableHtml(): Closure
     {
         return function (int $options = LIBXML_HTML_NOIMPLIED, ?string $overrideEncoding = null): AssertableDocument {
-            return AssertableDocument::createFromString((string) $this->rendered, $options, $overrideEncoding);
+            return AssertableDocument::createFromString((string) $this, $options, $overrideEncoding);
         };
     }
 


### PR DESCRIPTION
This changes `$this->rendered` to `$this` which keeps it inline with the [TestViewMixins](https://github.com/ziadoz/assertable-html/blob/963d5d1ace691d52c5732d0af3c8321637115cc7/src/Mixins/TestViewMixins.php#L16)


This is because when we cast it to string, it calls the [same thing underneath](https://github.com/laravel/framework/blob/f5c017e7134ae627137ac2052491bd733a9beb73/src/Illuminate/Testing/TestComponent.php#L144) - but avoids the protected property. 